### PR TITLE
Attempt to use primary, default and viewed variants' images

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ module.exports = {
         spreeFeatures: {
           // Associate guest cart after the customer logs in. Requires Spree 4.3+
           associateGuestCart: false,
+          // Fetch basic information about products from the `primary_variant` relationship. Requires Spree 4.3+
+          fetchPrimaryVariant: false
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lint-staged": "^10.0.7",
     "rimraf": "^3.0.2",
     "rollup": "^1.25.2",
-    "rollup-plugin-typescript2": "^0.29.0",
+    "rollup-plugin-typescript2": "^0.30.0",
     "ts-jest": "^26.4.3",
     "ts-node": "^8.4.1",
     "tslib": "^2.0.3",

--- a/packages/api-client/src/api/getProduct/index.ts
+++ b/packages/api-client/src/api/getProduct/index.ts
@@ -2,14 +2,18 @@ import { ApiContext } from '../../types';
 import { addHostToProductImages, deserializeSingleProductVariants } from '../serializers/product';
 
 export default async function getProduct({ client, config }: ApiContext, { slug }) {
+  const variantFields = 'name,description,slug,sku,price,display_price,in_stock,product,images,option_values,is_master';
+
   const result = await client.products.show(
     slug,
     {
-      include: 'variants.option_values,option_types,product_properties,taxons,taxons.parent,images',
       fields: {
-        product: 'name,variants,option_types,product_properties,taxons',
-        variant: 'name,description,slug,sku,price,display_price,in_stock,product,images,option_values'
-      }
+        product: 'name,primary_variant,default_variant,variants,option_types,product_properties,taxons',
+        variant: variantFields,
+        primary_variant: variantFields,
+        default_variant: variantFields
+      },
+      include: 'primary_variant,default_variant,variants.option_values,option_types,product_properties,taxons,taxons.parent,images'
     }
   );
 

--- a/packages/api-client/src/api/getProduct/index.ts
+++ b/packages/api-client/src/api/getProduct/index.ts
@@ -2,16 +2,12 @@ import { ApiContext } from '../../types';
 import { addHostToProductImages, deserializeSingleProductVariants } from '../serializers/product';
 
 export default async function getProduct({ client, config }: ApiContext, { slug }) {
-  const variantFields = 'name,description,slug,sku,price,display_price,in_stock,product,images,option_values,is_master';
-
   const result = await client.products.show(
     slug,
     {
       fields: {
-        product: 'name,primary_variant,default_variant,variants,option_types,product_properties,taxons',
-        variant: variantFields,
-        primary_variant: variantFields,
-        default_variant: variantFields
+        product: 'name,slug,sku,description,primary_variant,default_variant,variants,option_types,product_properties,taxons',
+        variant: 'sku,price,display_price,in_stock,product,images,option_values,is_master'
       },
       include: 'primary_variant,default_variant,variants.option_values,option_types,product_properties,taxons,taxons.parent,images'
     }

--- a/packages/api-client/src/api/getProduct/index.ts
+++ b/packages/api-client/src/api/getProduct/index.ts
@@ -2,6 +2,14 @@ import { ApiContext } from '../../types';
 import { addHostToProductImages, deserializeSingleProductVariants } from '../serializers/product';
 
 export default async function getProduct({ client, config }: ApiContext, { slug }) {
+  let include;
+
+  if (config.spreeFeatures.fetchPrimaryVariant) {
+    include = 'primary_variant,default_variant,variants.option_values,option_types,product_properties,taxons,taxons.parent,images';
+  } else {
+    include = 'default_variant,variants.option_values,option_types,product_properties,taxons,taxons.parent,images';
+  }
+
   const result = await client.products.show(
     slug,
     {
@@ -9,7 +17,7 @@ export default async function getProduct({ client, config }: ApiContext, { slug 
         product: 'name,slug,sku,description,primary_variant,default_variant,variants,option_types,product_properties,taxons',
         variant: 'sku,price,display_price,in_stock,product,images,option_values,is_master'
       },
-      include: 'primary_variant,default_variant,variants.option_values,option_types,product_properties,taxons,taxons.parent,images'
+      include
     }
   );
 

--- a/packages/api-client/src/api/getProducts/index.ts
+++ b/packages/api-client/src/api/getProducts/index.ts
@@ -3,6 +3,13 @@ import { addHostToProductImages, deserializeLimitedVariants, deserializeSearchMe
 
 export default async function getProducts({ client, config }: ApiContext, params) {
   const { id, categoryId, page, sort, optionValuesIds, price, itemsPerPage, term } = params;
+  let include;
+
+  if (config.spreeFeatures.fetchPrimaryVariant) {
+    include = 'primary_variant,default_variant,variants.option_values,option_types,taxons,images';
+  } else {
+    include = 'default_variant,variants.option_values,option_types,taxons,images';
+  }
 
   const result = await client.products.list({
     filter: {
@@ -16,7 +23,7 @@ export default async function getProducts({ client, config }: ApiContext, params
       product: 'name,slug,sku,description,primary_variant,default_variant,variants,option_types,taxons',
       variant: 'sku,price,display_price,in_stock,product,images,option_values,is_master'
     },
-    include: 'primary_variant,default_variant,variants.option_values,option_types,taxons,images',
+    include,
     page,
     sort,
     per_page: itemsPerPage

--- a/packages/api-client/src/api/getProducts/index.ts
+++ b/packages/api-client/src/api/getProducts/index.ts
@@ -3,6 +3,7 @@ import { addHostToProductImages, deserializeLimitedVariants, deserializeSearchMe
 
 export default async function getProducts({ client, config }: ApiContext, params) {
   const { id, categoryId, page, sort, optionValuesIds, price, itemsPerPage, term } = params;
+  const variantFields = 'name,slug,sku,price,display_price,product,images,option_values,is_master';
 
   const result = await client.products.list({
     filter: {
@@ -13,10 +14,12 @@ export default async function getProducts({ client, config }: ApiContext, params
       name: term
     },
     fields: {
-      product: 'name,slug,variants,option_types,taxons',
-      variant: 'name,slug,sku,price,display_price,product,images,option_values'
+      product: 'name,slug,primary_variant,default_variant,variants,option_types,taxons',
+      variant: variantFields,
+      primary_variant: variantFields,
+      default_variant: variantFields
     },
-    include: 'variants.option_values,option_types,taxons,images',
+    include: 'primary_variant,default_variant,variants.option_values,option_types,taxons,images',
     page,
     sort,
     per_page: itemsPerPage

--- a/packages/api-client/src/api/getProducts/index.ts
+++ b/packages/api-client/src/api/getProducts/index.ts
@@ -3,7 +3,6 @@ import { addHostToProductImages, deserializeLimitedVariants, deserializeSearchMe
 
 export default async function getProducts({ client, config }: ApiContext, params) {
   const { id, categoryId, page, sort, optionValuesIds, price, itemsPerPage, term } = params;
-  const variantFields = 'name,slug,sku,price,display_price,product,images,option_values,is_master';
 
   const result = await client.products.list({
     filter: {
@@ -14,10 +13,8 @@ export default async function getProducts({ client, config }: ApiContext, params
       name: term
     },
     fields: {
-      product: 'name,slug,primary_variant,default_variant,variants,option_types,taxons',
-      variant: variantFields,
-      primary_variant: variantFields,
-      default_variant: variantFields
+      product: 'name,slug,sku,description,primary_variant,default_variant,variants,option_types,taxons',
+      variant: 'sku,price,display_price,in_stock,product,images,option_values,is_master'
     },
     include: 'primary_variant,default_variant,variants.option_values,option_types,taxons,images',
     page,

--- a/packages/api-client/src/api/serializers/common.ts
+++ b/packages/api-client/src/api/serializers/common.ts
@@ -1,11 +1,13 @@
 export const filterAttachments = (attachments, type, ids) =>
-  attachments.filter((e) => e.type === type && ids.includes(e.id));
+  attachments
+    .filter((attachment) => attachment.type === type && ids.includes(attachment.id));
 
 export const extractRelationships = (attachments, type, relationship, item) => {
-  if (!item.relationships[relationship]) return [];
-  const relationships = item.relationships[relationship].data;
+  const relationships = item.relationships[relationship]?.data;
+
+  if (!relationships) return [];
 
   return Array.isArray(relationships)
     ? filterAttachments(attachments, type, relationships.map((e) => e.id))
-    : filterAttachments(attachments, type, relationships.id);
+    : filterAttachments(attachments, type, [relationships.id]);
 };

--- a/packages/api-client/src/api/serializers/common.ts
+++ b/packages/api-client/src/api/serializers/common.ts
@@ -1,13 +1,20 @@
-export const filterAttachments = (attachments, type, ids) =>
+import type { JsonApiDocument } from '@spree/storefront-api-v2-sdk/types/interfaces/JsonApi';
+
+export const filterAttachments = (attachments: JsonApiDocument[], type: string, ids: string[]): JsonApiDocument[] =>
   attachments
     .filter((attachment) => attachment.type === type && ids.includes(attachment.id));
 
-export const extractRelationships = (attachments, type, relationship, item) => {
-  const relationships = item.relationships[relationship]?.data;
+export const extractRelationships = (
+  attachments: JsonApiDocument[],
+  documentType: string,
+  relationshipsName: string,
+  item: JsonApiDocument
+): JsonApiDocument[] => {
+  const relationships: JsonApiDocument | JsonApiDocument[] = item.relationships[relationshipsName]?.data;
 
   if (!relationships) return [];
 
-  return Array.isArray(relationships)
-    ? filterAttachments(attachments, type, relationships.map((e) => e.id))
-    : filterAttachments(attachments, type, [relationships.id]);
+  if (!Array.isArray(relationships)) throw new Error(`Expected ${relationshipsName} to be a one-to-many relation.`);
+
+  return filterAttachments(attachments, documentType, relationships.map((relationship) => relationship.id));
 };

--- a/packages/api-client/src/api/serializers/product.ts
+++ b/packages/api-client/src/api/serializers/product.ts
@@ -2,27 +2,35 @@ import { JsonApiDocument, JsonApiResponse } from '@spree/storefront-api-v2-sdk/t
 import { ApiConfig, ProductVariant, OptionType, OptionValue } from '../../types';
 import { extractRelationships, filterAttachments } from './common';
 
-const deserializeImages = (included, defaultVariant, variant) => {
-  let defaultVariantImageIds = [];
-  if (defaultVariant.images && defaultVariant.images.data) {
-    defaultVariantImageIds = defaultVariant.images.data.map((e) => e.id);
-  }
-  let variantImageIds = [];
-  if (variant.relationships.images && variant.relationships.images.data) {
-    variantImageIds = variant.relationships.images.data.map((e) => e.id);
+const deserializeImages = (included, mainVariant, fallbackVariant) => {
+  let mainVariantImageIds = [];
+
+  if (mainVariant) {
+    mainVariantImageIds = mainVariant.relationships.images.data.map((e) => e.id);
   }
 
-  const imageIds = new Set(defaultVariantImageIds.concat(variantImageIds));
+  let fallbackVariantImageIds = [];
+
+  if (fallbackVariant) {
+    fallbackVariantImageIds = fallbackVariant.relationships.images.data.map((e) => e.id);
+  }
+
+  const imageIds = new Set(mainVariantImageIds.concat(fallbackVariantImageIds));
 
   const images = filterAttachments(included, 'image', Array.from(imageIds));
-  return images.map(image => ({
-    id: image.id,
-    styles: image.attributes.styles.map(style => ({
-      url: style.url,
-      width: parseInt(style.width, 10),
-      height: parseInt(style.height, 10)
-    }))
-  }));
+
+  const sortedImages = images
+    .sort((image1, image2) => Math.sign(image1.attributes.position - image2.attributes.position));
+
+  return sortedImages
+    .map(image => ({
+      id: image.id,
+      styles: image.attributes.styles.map(style => ({
+        url: style.url,
+        width: parseInt(style.width, 10),
+        height: parseInt(style.height, 10)
+      }))
+    }));
 };
 
 const deserializeProperties = (included, product) => {
@@ -36,6 +44,7 @@ const deserializeProperties = (included, product) => {
 
 const deserializeOptionTypes = (included, product): OptionType[] => {
   const optionTypes = extractRelationships(included, 'option_type', 'option_types', product);
+
   return optionTypes.map(optionType => ({
     id: optionType.id,
     name: optionType.attributes.name,
@@ -46,6 +55,7 @@ const deserializeOptionTypes = (included, product): OptionType[] => {
 
 const deserializeOptionValues = (included, variant): OptionValue[] => {
   const optionValues = extractRelationships(included, 'option_value', 'option_values', variant);
+
   return optionValues.map(optionValue => ({
     id: optionValue.id,
     name: optionValue.attributes.name,
@@ -80,45 +90,95 @@ const buildBreadcrumbs = (included, product) => {
   return breadcrumbs;
 };
 
-const deserializeProductVariant = (product, variant, defaultVariant, attachments): ProductVariant => ({
-  _id: variant.id,
+const deserializeProductVariant = (product, mainVariant, fallbackVariant, attachments): ProductVariant => ({
+  _id: mainVariant.id,
   _productId: product.id,
-  _variantId: variant.id,
-  _description: variant.attributes.description || product.attributes.description,
-  _categoriesRef: product.relationships.taxons.data.map((t) => t.id),
+  _variantId: mainVariant.id,
+  _description: mainVariant.attributes.description || product.attributes.description,
+  _categoriesRef: product.relationships.taxons.data.map((taxon) => taxon.id),
   name: product.attributes.name,
   slug: product.attributes.slug,
   sku: product.attributes.sku,
   optionTypes: deserializeOptionTypes(attachments, product),
-  optionValues: deserializeOptionValues(attachments, variant),
-  images: deserializeImages(attachments, defaultVariant, variant),
+  optionValues: deserializeOptionValues(attachments, mainVariant),
+  images: deserializeImages(attachments, mainVariant, fallbackVariant),
   breadcrumbs: buildBreadcrumbs(attachments, product),
   properties: deserializeProperties(attachments, product),
-  displayPrice: variant.attributes.display_price,
+  displayPrice: mainVariant.attributes.display_price,
   price: {
-    original: variant.attributes.price,
-    current: variant.attributes.price
+    original: mainVariant.attributes.price,
+    current: mainVariant.attributes.price
   },
-  inStock: variant.attributes.in_stock
+  inStock: mainVariant.attributes.in_stock
 });
 
-const findProductVariants = (product, included) =>
-  included.filter((e) => e.type === 'variant' && e.relationships.product.data.id === product.id);
+const groupIncluded = (included, discriminators) => {
+  const discriminatorsKeys = Object.keys(discriminators);
 
-export const deserializeSingleProductVariants = (apiProduct) => {
-  const variants = findProductVariants(apiProduct.data, apiProduct.included);
-  const defaultVariant = variants.find((e) => e.attributes.is_master) || variants[0];
-  return variants.map((variant) => deserializeProductVariant(apiProduct.data, variant, defaultVariant, apiProduct.included));
+  const emptyGroups = discriminatorsKeys.reduce((accumulatedGroups, discriminatorKey) => {
+    accumulatedGroups[discriminatorKey] = [];
+
+    return accumulatedGroups;
+  }, {});
+
+  const filledGroups = included.reduce((accumulatedGroups, document) => {
+    discriminatorsKeys.forEach((discriminatorKey) => {
+      if (discriminators[discriminatorKey](document)) {
+        accumulatedGroups[discriminatorKey].push(document);
+      }
+    });
+
+    return accumulatedGroups;
+  }, emptyGroups);
+
+  return filledGroups;
 };
 
-export const deserializeLimitedVariants = (apiProducts) =>
-  apiProducts.data.map((product) => {
-    const attachments = apiProducts.included;
-    const variants = findProductVariants(product, attachments);
-    const defaultVariant = variants.find((e) => e.attributes.is_master) || variants[0];
+const isVariantOfParent = (document, parentId) => document.type === 'variant' && document.relationships.product.data.id === parentId;
 
-    return deserializeProductVariant(product, defaultVariant, defaultVariant, attachments);
+export const deserializeSingleProductVariants = (apiProduct) => {
+  const attachments = apiProduct.included;
+  const productId = apiProduct.data.id;
+
+  const variants = groupIncluded(
+    attachments,
+    {
+      primaryVariants: (document) => (isVariantOfParent(document, productId) && document.attributes.is_master),
+      optionVariants: (document) => (isVariantOfParent(document, productId) && !document.attributes.is_master)
+    }
+  );
+  const primaryVariant = variants.primaryVariants[0];
+
+  return variants.optionVariants.map(
+    (variant) => deserializeProductVariant(apiProduct.data, variant, primaryVariant, attachments)
+  );
+};
+
+export const deserializeLimitedVariants = (apiProducts) => {
+  const attachments = apiProducts.included;
+
+  return apiProducts.data.map((product) => {
+    const productId = product.id;
+    const defaultVariantId = product.relationships.default_variant.data.id;
+
+    const variants = groupIncluded(
+      attachments,
+      {
+        primaryVariants: (document) => (isVariantOfParent(document, productId) && document.attributes.is_master),
+        defaultOptionVariants: (document) => (
+          isVariantOfParent(document, productId) &&
+          !document.attributes.is_master &&
+          defaultVariantId === document.id
+        )
+      }
+    );
+
+    const primaryVariant = variants.primaryVariants[0];
+    const defaultOptionVariant = variants.defaultOptionVariants[0];
+
+    return deserializeProductVariant(product, primaryVariant, defaultOptionVariant, attachments);
   });
+};
 
 export const deserializeSearchMetadata = (searchMetadata) => ({
   totalPages: parseInt(searchMetadata.total_pages, 10),

--- a/packages/api-client/src/api/serializers/product.ts
+++ b/packages/api-client/src/api/serializers/product.ts
@@ -1,5 +1,5 @@
-import { JsonApiDocument, JsonApiResponse } from '@spree/storefront-api-v2-sdk/types/interfaces/JsonApi';
-import { ApiConfig, ProductVariant, OptionType, OptionValue } from '../../types';
+import type { JsonApiDocument, JsonApiResponse } from '@spree/storefront-api-v2-sdk/types/interfaces/JsonApi';
+import type { ApiConfig, ProductVariant, OptionType, OptionValue, Image } from '../../types';
 import { extractRelationships, filterAttachments } from './common';
 
 const groupIncluded = (included, discriminators) => {
@@ -26,7 +26,7 @@ const groupIncluded = (included, discriminators) => {
 
 const isVariantOfProduct = (document, productId) => document.type === 'variant' && document.relationships.product.data.id === productId;
 
-const deserializeImages = (included: JsonApiDocument[], mainVariant: JsonApiDocument, fallbackVariant?: JsonApiDocument) => {
+const deserializeImages = (included: JsonApiDocument[], mainVariant: JsonApiDocument, fallbackVariant?: JsonApiDocument): Image[] => {
   const mainVariantImageIds = mainVariant.relationships.images.data.map((imageIdentifier) => imageIdentifier.id);
 
   let fallbackVariantImageIds = [];
@@ -35,7 +35,7 @@ const deserializeImages = (included: JsonApiDocument[], mainVariant: JsonApiDocu
     fallbackVariantImageIds = fallbackVariant.relationships.images.data.map((imageIdentifier) => imageIdentifier.id);
   }
 
-  const imageIds = new Set(mainVariantImageIds.concat(fallbackVariantImageIds));
+  const imageIds = new Set<string>(mainVariantImageIds.concat(fallbackVariantImageIds));
 
   const images = filterAttachments(included, 'image', Array.from(imageIds));
 
@@ -44,7 +44,7 @@ const deserializeImages = (included: JsonApiDocument[], mainVariant: JsonApiDocu
 
   return sortedImages
     .map(image => ({
-      id: image.id,
+      id: parseInt(image.id, 10),
       styles: image.attributes.styles.map(style => ({
         url: style.url,
         width: parseInt(style.width, 10),
@@ -66,7 +66,8 @@ const deserializeOptionTypes = (included, product): OptionType[] => {
   const optionTypes = extractRelationships(included, 'option_type', 'option_types', product);
 
   return optionTypes.map(optionType => ({
-    id: optionType.id,
+    id: parseInt(optionType.id, 10),
+    type: optionType.type,
     name: optionType.attributes.name,
     position: optionType.attributes.position,
     presentation: optionType.attributes.presentation
@@ -77,7 +78,8 @@ const deserializeOptionValues = (included, variant): OptionValue[] => {
   const optionValues = extractRelationships(included, 'option_value', 'option_values', variant);
 
   return optionValues.map(optionValue => ({
-    id: optionValue.id,
+    id: parseInt(optionValue.id, 10),
+    type: optionValue.attributes.type,
     name: optionValue.attributes.name,
     position: optionValue.attributes.position,
     presentation: optionValue.attributes.presentation,

--- a/packages/api-client/src/index.server.ts
+++ b/packages/api-client/src/index.server.ts
@@ -37,7 +37,8 @@ import makeOrder from './api/makeOrder';
 const defaultSettings = {
   backendUrl: 'http://localhost:4000',
   spreeFeatures: {
-    associateGuestCart: false
+    associateGuestCart: false,
+    fetchPrimaryVariant: false
   }
 };
 

--- a/packages/api-client/src/types/index.ts
+++ b/packages/api-client/src/types/index.ts
@@ -42,6 +42,7 @@ export type ApiConfig = {
   backendUrl: string;
   spreeFeatures: {
     associateGuestCart: boolean;
+    fetchPrimaryVariant: boolean;
   }
 }
 

--- a/packages/api-client/tsconfig.json
+++ b/packages/api-client/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
-  "exclude": ["node_modules", "lib"]
+  "exclude": ["node_modules", "lib"],
+  "compilerOptions": {
+    "importHelpers": true
+  }
 }

--- a/packages/theme/middleware.config.js
+++ b/packages/theme/middleware.config.js
@@ -6,7 +6,9 @@ module.exports = {
         backendUrl: process.env.BACKEND_URL,
         spreeFeatures: {
           // Associate guest cart after the customer logs in. Requires Spree 4.3+
-          associateGuestCart: false
+          associateGuestCart: false,
+          // Fetch basic information about products from the `primary_variant` relationship. Requires Spree 4.3+
+          fetchPrimaryVariant: false
         }
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2394,13 +2394,12 @@
   resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.11.tgz#aeb16f50649a91af79dbe36574b66d0f9e4d9f71"
   integrity sha512-3NsZsJIA/22P3QUyrEDNA2D133H4j224twJrdipXN38dpnIOzAbUDtOwkcJ5pXmn75w7LSQDjA4tO9dm1XlqlA==
 
-"@rollup/pluginutils@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
-  integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
+"@rollup/pluginutils@^4.1.0":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-4.1.1.tgz#1d4da86dd4eded15656a57d933fda2b9a08d47ec"
+  integrity sha512-clDjivHqWGXi7u+0d2r2sBi4Ie6VLEAzWMIkvJLnDmxoOhBYOTfzGbOQBA32THHm11/LiJbd01tJUpJsbshSWQ==
   dependencies:
-    "@types/estree" "0.0.39"
-    estree-walker "^1.0.1"
+    estree-walker "^2.0.1"
     picomatch "^2.2.2"
 
 "@spree/storefront-api-v2-sdk@^4.4.3":
@@ -2533,11 +2532,6 @@
   version "0.0.46"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.46.tgz#0fb6bfbbeabd7a30880504993369c4bf1deab1fe"
   integrity sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==
-
-"@types/estree@0.0.39":
-  version "0.0.39"
-  resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
-  integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
 
 "@types/etag@^1.8.0":
   version "1.8.0"
@@ -6073,10 +6067,10 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
   integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
-estree-walker@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
-  integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
+estree-walker@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-2.0.2.tgz#52f010178c2a4c117a7757cfe942adb7d2da4cac"
+  integrity sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -11873,14 +11867,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@1.17.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
-  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
-  dependencies:
-    path-parse "^1.0.6"
-
-resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.2.0, resolve@^1.20.0:
+resolve@1.20.0, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.13.1, resolve@^1.14.2, resolve@^1.17.0, resolve@^1.2.0, resolve@^1.20.0:
   version "1.20.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
   integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
@@ -11963,16 +11950,16 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
     hash-base "^3.0.0"
     inherits "^2.0.1"
 
-rollup-plugin-typescript2@^0.29.0:
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.29.0.tgz#b7ad83f5241dbc5bdf1e98d9c3fca005ffe39e1a"
-  integrity sha512-YytahBSZCIjn/elFugEGQR5qTsVhxhUwGZIsA9TmrSsC88qroGo65O5HZP/TTArH2dm0vUmYWhKchhwi2wL9bw==
+rollup-plugin-typescript2@^0.30.0:
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.30.0.tgz#1cc99ac2309bf4b9d0a3ebdbc2002aecd56083d3"
+  integrity sha512-NUFszIQyhgDdhRS9ya/VEmsnpTe+GERDMmFo0Y+kf8ds51Xy57nPNGglJY+W6x1vcouA7Au7nsTgsLFj2I0PxQ==
   dependencies:
-    "@rollup/pluginutils" "^3.1.0"
+    "@rollup/pluginutils" "^4.1.0"
     find-cache-dir "^3.3.1"
     fs-extra "8.1.0"
-    resolve "1.17.0"
-    tslib "2.0.1"
+    resolve "1.20.0"
+    tslib "2.1.0"
 
 rollup@^1.25.2:
   version "1.32.1"
@@ -13347,10 +13334,10 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
-  integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
+tslib@2.1.0, tslib@^2.0.3:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
+  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
 tslib@^1.8.1, tslib@^1.9.0:
   version "1.14.1"
@@ -13361,11 +13348,6 @@ tslib@^2.0.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.2.0.tgz#fb2c475977e35e241311ede2693cee1ec6698f5c"
   integrity sha512-gS9GVHRU+RGn5KQM2rllAlR3dU6m7AcpJKdtH8gFvQiC4Otgk98XnmMU+nZenHt/+VhnBPWwgrJsyrdcw6i23w==
-
-tslib@^2.0.3:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
-  integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
 
 tsutils@^3.17.1:
   version "3.21.0"


### PR DESCRIPTION
A product may have no images, images associated with the primary variant, images associated with the default or miscellaneous variants. This PR handles most possible combinations. It doesn't search for images in variants other than current, primary or default. Still, it's an improvement over the current approach and finds more images.