### PR TITLE
Ignore non camel case property names

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -73,7 +73,7 @@
     "no-useless-return": 2,
     "no-console": 0,
     "global-require": 1,
-    "camelcase": 2,
+    "camelcase": [2, { "properties": "never" }],
     "computed-property-spacing": 2,
     "consistent-this": 2,
     "func-call-spacing": 2,

--- a/packages/api-client/src/api/addToCart/index.ts
+++ b/packages/api-client/src/api/addToCart/index.ts
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 import { ApiContext, Cart } from '../../types';
 import { cartParams } from '../common/cart';
 import { deserializeCart } from '../serializers/cart';

--- a/packages/api-client/src/api/authentication/getCurrentBearerToken.ts
+++ b/packages/api-client/src/api/authentication/getCurrentBearerToken.ts
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 import { ApiContext } from '../../types';
 
 export default async function getCurrentBearerToken({ client, config }: ApiContext): Promise<string> {

--- a/packages/api-client/src/api/changePassword/index.ts
+++ b/packages/api-client/src/api/changePassword/index.ts
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 import { ApiContext } from '../../types';
 import getCurrentBearerToken from '../authentication/getCurrentBearerToken';
 

--- a/packages/api-client/src/api/getCategory/index.ts
+++ b/packages/api-client/src/api/getCategory/index.ts
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 import { ApiContext, Category } from '../../types';
 import { deserializeCategories } from '../serializers/category';
 

--- a/packages/api-client/src/api/getOrders/index.ts
+++ b/packages/api-client/src/api/getOrders/index.ts
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 import { Logger } from '@vue-storefront/core';
 import { ApiContext, Order } from '../../types';
 import getCurrentBearerToken from '../authentication/getCurrentBearerToken';

--- a/packages/api-client/src/api/getProducts/index.ts
+++ b/packages/api-client/src/api/getProducts/index.ts
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 import { ApiContext } from '../../types';
 import { addHostToProductImages, deserializeLimitedVariants, deserializeSearchMetadata } from '../serializers/product';
 

--- a/packages/api-client/src/api/saveCheckoutBillingAddress/index.ts
+++ b/packages/api-client/src/api/saveCheckoutBillingAddress/index.ts
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 import { Address, ApiContext } from '../../types';
 import getCurrentCartToken from '../authentication/getCurrentCartToken';
 import { serializeAddress } from '../serializers/address';

--- a/packages/api-client/src/api/saveCheckoutShippingAddress/index.ts
+++ b/packages/api-client/src/api/saveCheckoutShippingAddress/index.ts
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 import { Address, ApiContext } from '../../types';
 import getCurrentCartToken from '../authentication/getCurrentCartToken';
 import { serializeAddress } from '../serializers/address';

--- a/packages/api-client/src/api/saveShippingMethod/index.ts
+++ b/packages/api-client/src/api/saveShippingMethod/index.ts
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 import { ApiContext } from '../../types';
 import getCurrentCartToken from '../authentication/getCurrentCartToken';
 

--- a/packages/api-client/src/api/serializers/address.ts
+++ b/packages/api-client/src/api/serializers/address.ts
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 import { AccountAddressAttr } from '@spree/storefront-api-v2-sdk/types/interfaces/Account';
 import { IAddress } from '@spree/storefront-api-v2-sdk/types/interfaces/attributes/Address';
 import { Address } from '../../types';

--- a/packages/api-client/src/api/serializers/cart.ts
+++ b/packages/api-client/src/api/serializers/cart.ts
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 import { OrderAttr } from '@spree/storefront-api-v2-sdk/types/interfaces/Order';
 import { CouponCode as CouponCodeAttr } from '@spree/storefront-api-v2-sdk/types/interfaces/endpoints/CartClass';
 import { Cart, CouponCode, LineItem } from '../../types';

--- a/packages/api-client/src/api/serializers/country.ts
+++ b/packages/api-client/src/api/serializers/country.ts
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 export const deserializeState = (apiState) => ({
   code: apiState.attributes.abbr,
   name: apiState.attributes.name

--- a/packages/api-client/src/api/updateItemQuantity/index.ts
+++ b/packages/api-client/src/api/updateItemQuantity/index.ts
@@ -1,5 +1,3 @@
-/* eslint-disable camelcase */
-
 import { ApiContext, Cart } from '../../types';
 import { cartParams } from '../common/cart';
 import { deserializeCart } from '../serializers/cart';


### PR DESCRIPTION
While using camel case is common practice in JavaScript, some libraries or data may not follow this rule. Easing the `camelcase` ESLint rule removes errors associated with providing non camel case properties. For example, changing the `camelcase` setting will allow the following argument structure provided to a function:
```js
{
  primary_variant: {...}
}
```

By changing the rule in `.eslintrc` we would avoid adding `/* eslint-disable camelcase */` in modules.