### PR TITLE
Update cart item count

### DIFF
--- a/packages/api-client/src/api/getCart/index.ts
+++ b/packages/api-client/src/api/getCart/index.ts
@@ -17,6 +17,7 @@ const emptyCart: Cart = {
   taxTotalAmount: 0.0,
   adjustmentTotal: '',
   lineItems: [],
+  itemCount: 0,
   completedAt: new Date(),
   address: {
     shipping: undefined,

--- a/packages/api-client/src/api/serializers/cart.ts
+++ b/packages/api-client/src/api/serializers/cart.ts
@@ -87,6 +87,7 @@ export const deserializeCart = (apiCart: OrderAttr, included: any[], config: any
   taxTotalAmount: parseFloat(apiCart.attributes.tax_total),
   adjustmentTotal: apiCart.attributes.display_adjustment_total,
   lineItems: filterIncludedLineItems(included).map(item => deserializeLineItem(item, included, config)),
+  itemCount: apiCart.attributes.item_count,
   address: findAddress(apiCart, included),
   completedAt: apiCart.attributes.completed_at,
   token: apiCart.attributes.token

--- a/packages/api-client/src/types/cart.ts
+++ b/packages/api-client/src/types/cart.ts
@@ -34,6 +34,7 @@ export type Cart = {
   taxTotalAmount: number;
   adjustmentTotal: string;
   lineItems: LineItem[];
+  itemCount: number;
   completedAt: Date;
   token: string;
   address: {

--- a/packages/composables/src/getters/cartGetters.ts
+++ b/packages/composables/src/getters/cartGetters.ts
@@ -36,7 +36,7 @@ export const getCartTotals = (cart: Cart): AgnosticTotals => {
 
 export const getCartShippingPrice = (cart: Cart): number => cart.shipTotalAmount;
 
-export const getCartTotalItems = (cart: Cart): number => cart?.lineItems.length || 0;
+export const getCartTotalItems = (cart: Cart): number => cart?.itemCount || 0;
 
 export const getFormattedPrice = (price: number): string => String(price);
 


### PR DESCRIPTION
As discussed, we should use item count from Spree, to make the displayed count consistent with Spree's built-in frontend